### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -14,17 +14,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "tasksRunnerOptions": {
-    "default": {
-      "options": {
-        "useCloud": false
-      }
-    }
-  },
-
-  "targetDefaults": {
-    "e2e-ci--**/*": {
-      "dependsOn": ["^build"]
-    }
-  }
+  "tasksRunnerOptions": { "default": { "options": { "useCloud": false } } },
+  "targetDefaults": { "e2e-ci--**/*": { "dependsOn": ["^build"] } },
+  "nxCloudId": "68189d12c5bf9c39bd3339e7"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/68176ea31b6283edd08d358f/workspaces/68189d12c5bf9c39bd3339e7

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.